### PR TITLE
Crop-preview with aspect ratio keeping support (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ elements: {
 	preview: {
 		el: 0, // css selector
 		width: 0,
-		height: 0
+		height: 0,
+		keepAspectRatio: false // optional: false to stretch cropped image to preview area, true scale image proportionally
 	},
 	// Total size of queue
 	size: '[data-fileapi="size"]',
@@ -169,6 +170,7 @@ elements: {
 			get: 0, // eg: function($el, file){ $el.append('<i class="icon icon_'+file.name.split('.').pop()+'"></i>'); }
 			width: 0,
 			height: 0,
+			keepAspectRatio: false // optional: false to stretch cropped image to preview area, true scale image proportionally
 		}
 	},
 	// Drag and drop
@@ -249,7 +251,7 @@ $('#userpic').fileapi({
 			, bgColor: '#fff'
 			, maxSize: [320, 240] // viewport max size
 			, minSize: [100, 100] // crop min size
-			, aspectRatio: 1
+			, aspectRatio: 1      // optional, aspect ratio: 0 - disable, >0 - fixed, remove this option: autocalculation from minSize
 			, onSelect: function (coords){
 				$('#userpic').fileapi('crop', imageFile, coords);
 			}

--- a/jquery.fileapi.js
+++ b/jquery.fileapi.js
@@ -832,12 +832,40 @@
 
 						var rx = preview.width/coords.w, ry = preview.height/coords.h;
 						
+						if( preview.keepAspectRatio ){
+							var mx = preview.width, my = preview.height;
+
+							if (rx > 1 && ry > 1){ // image is smaller than preview (no scale)
+								rx = ry = 1;
+								my = coords.h;
+								mx = coords.w;
+
+							} else { // image is bigger than preview (scale)
+								if( rx < ry ){
+									ry = rx;
+									my = preview.width * coords.h / coords.w;
+								} else {
+									rx = ry;
+									mx = preview.height * coords.w / coords.h;
+								}
+							}
+						}
+
 						$el.find('>div>div').css({
 							  width:	Math.round(rx * info.width)
 							, height:	Math.round(ry * info.height)
 							, marginLeft:	-Math.round(rx * coords.x)
 							, marginTop:	-Math.round(ry * coords.y)
 						});
+
+						if( preview.keepAspectRatio ){ // create side gaps
+							$el.find('>div').css({
+								  width:	Math.round(mx)
+								, height:	Math.round(my)
+								, marginLeft:	mx < preview.width  ? Math.round((preview.width - mx) / 2)  : 0
+								, marginTop:	my < preview.height ? Math.round((preview.height - my) / 2) : 0
+							});
+						}
 					}
 				}));
 			}


### PR DESCRIPTION
Add possibility to make crop-preview not aspect ratio fixed. Currently images are forced to scaled in preview loosing selection aspect ratio. If service accepts images with different ratio, we need to give user access to this option. After merging this request it will be possible. To do it `aspectRatio` option must be removed from options in `$('...').cropper()`, and `keepAspectRatio: true` option must be added in `$('...').fileapi({elements:{preview:{}}})` option.
