### PR TITLE
use protocol-relative URL to load resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 	<meta name="keywords" content="jQuery, Plugin, FileAPI, html5, upload, multiupload, dragndrop, chunk, chunked, file, image, crop, resize, rotate, html5, rubaxa"/>
 	<meta name="description" content="jQuery.fn.fileapi — the best plugin for jQuery (it is true)"/>
 
-	<link href="http://fonts.googleapis.com/css?family=Roboto:300" rel="stylesheet" type="text/css"/>
+	<link href="//fonts.googleapis.com/css?family=Roboto:300" rel="stylesheet" type="text/css"/>
 	<link href="./statics/main.css" rel="stylesheet" type="text/css"/>
 	<link href="./jcrop/jquery.Jcrop.min.css" rel="stylesheet" type="text/css"/>
 
@@ -375,7 +375,7 @@
 
 			<div style="margin-top: 80px;">
 				<div id="rubaxa-repos">Loading&hellip;</div>
-				<script src="http://rubaxa.github.io/repos.js"></script>
+				<script src="//rubaxa.github.io/repos.js"></script>
 			</div>
 		</div>
 


### PR DESCRIPTION
browser will tell users that the page contains some insecure resources, use protocol-relative URL can prevent this issue.

reference : [The Protocol-relative URL](http://www.paulirish.com/2010/the-protocol-relative-url/)
